### PR TITLE
Remove unnecessary code and improve test coverage

### DIFF
--- a/src/Amara/Varcon/TranslationProvider.php
+++ b/src/Amara/Varcon/TranslationProvider.php
@@ -43,10 +43,6 @@ class TranslationProvider implements TranslationProviderInterface
     {
         $fileHandle = fopen($this->filePath, 'r');
 
-        if (!$fileHandle) {
-            throw new \RuntimeException(sprintf('Unable to open file: %s', $filename));
-        }
-
         $trans = [];
 
         while (false !== ($line = stream_get_line($fileHandle, null, PHP_EOL.PHP_EOL))) {

--- a/src/Amara/Varcon/TranslationProvider.php
+++ b/src/Amara/Varcon/TranslationProvider.php
@@ -41,6 +41,10 @@ class TranslationProvider implements TranslationProviderInterface
      */
     public function getTranslations($from, $to, $threshold = 80)
     {
+        if (!file_exists($this->filePath)) {
+            throw new \RuntimeException(sprintf('File not found: %s', $this->filePath));
+        }
+
         $fileHandle = fopen($this->filePath, 'r');
 
         $trans = [];

--- a/src/Amara/Varcon/Translator.php
+++ b/src/Amara/Varcon/Translator.php
@@ -12,16 +12,16 @@ class Translator
     const QUESTIONABLE_MARK = 2;
 
     /**
-     * @var TranslationProvider
+     * @var TranslationProviderInterface
      */
     private $provider;
 
     /**
      * Translator constructor.
      *
-     * @param TranslationProvider|null $provider
+     * @param TranslationProviderInterface|null $provider
      */
-    public function __construct(TranslationProvider $provider = null)
+    public function __construct(TranslationProviderInterface $provider = null)
     {
         if (null === $provider) {
             $provider = new TranslationProvider;

--- a/tests/Amara/Varcon/TranslationProviderTest.php
+++ b/tests/Amara/Varcon/TranslationProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Amara\Varcon;
+
+use PHPUnit_Framework_TestCase;
+
+class TranslationProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetTranslationsFileNotFoundException()
+    {
+        $translationProvider = new TranslationProvider('random-name-2439857.txt');
+
+        $this->setExpectedException(\RuntimeException::class, 'File not found: ');
+        $translationProvider->getTranslations('B', 'A');
+    }
+}

--- a/tests/Amara/Varcon/TranslatorTest.php
+++ b/tests/Amara/Varcon/TranslatorTest.php
@@ -5,8 +5,23 @@ namespace Amara\Varcon\Tests;
 use Amara\Varcon\Translator;
 use PHPUnit_Framework_TestCase;
 
-class VarconTranslatorTest extends PHPUnit_Framework_TestCase
+class TranslatorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->translator = new Translator();
+
+        parent::setUp();
+    }
+
     /**
      * @return array
      */
@@ -14,18 +29,58 @@ class VarconTranslatorTest extends PHPUnit_Framework_TestCase
     {
         return [
             [
+                $questionable = Translator::QUESTIONABLE_IGNORE,
                 $british = 'My pyjama\'s colour is not as greyish as it looks',
                 $american = 'My pajama\'s color is not as grayish as it looks',
                 $canadian = 'My pyjama\'s colour is not as greyish as it looks',
                 $australian = 'My pyjama\'s colour is not as greyish as it looks',
                 $british_z = 'My pyjama\'s colour is not as greyish as it looks',
+                $variation = null,
             ],
             [
+                $questionable = Translator::QUESTIONABLE_IGNORE,
                 $british = 'The 50x50centimetres-cabinet is finally finalised',
                 $american = 'The 50x50centimeters-cabinet is finally finalized',
                 $canadian = 'The 50x50centimetres-cabinet is finally finalized',
                 $australian = 'The 50x50centimetres-cabinet is finally finalised',
                 $british_z = 'The 50x50centimetres-cabinet is finally finalized',
+                $variation = null,
+            ],
+            [
+                $questionable = Translator::QUESTIONABLE_IGNORE,
+                $british = 'No uncommon words here',
+                $american = 'No uncommon words here',
+                $canadian = 'No uncommon words here',
+                $australian = 'No uncommon words here',
+                $british_z = 'No uncommon words here',
+                $variation = 'No uncommon words here',
+            ],
+            [
+                $questionable = Translator::QUESTIONABLE_INCLUDE,
+                $british = ['One metre', 'One meter'],
+                $american = 'One meter',
+                $canadian = ['One metre', 'One meter'],
+                $australian = ['One metre', 'One meter'],
+                $british_z = ['One metre', 'One meter'],
+                $variation = null,
+            ],
+            [
+                $questionable = Translator::QUESTIONABLE_INCLUDE,
+                $british = ['adviser', 'advisor'],
+                $american = ['adviser', 'advisor'],
+                $canadian = ['adviser', 'advisor'],
+                $australian = ['adviser', 'advisor'],
+                $british_z = ['adviser', 'advisor'],
+                $variation = ['adviser', 'advisor'],
+            ],
+            [
+                $questionable = Translator::QUESTIONABLE_MARK,
+                $british = ['One metre high', 'One ?meter/metre? high'],
+                $american = 'One meter high',
+                $canadian = ['One metre high', 'One ?meter/metre? high'],
+                $australian = ['One metre high', 'One ?meter/metre? high'],
+                $british_z = ['One metre high', 'One ?meter/metre? high'],
+                $variation = null,
             ],
         ];
     }
@@ -35,29 +90,50 @@ class VarconTranslatorTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider translateDataProvider
      *
-     * @param string $british
-     * @param string $american
-     * @param string $canadian
-     * @param string $australian
-     * @param string $british_z
+     * @param int $questionable
+     * @param string|array $british
+     * @param string|array $american
+     * @param string|array $canadian
+     * @param string|array $australian
+     * @param string|array $british_z
+     * @param string|array|null $variation
      */
-    public function testTranslate($british, $american, $canadian, $australian, $british_z)
+    public function testTranslate($questionable, $british, $american, $canadian, $australian, $british_z, $variation)
     {
-        $translator = new Translator();
-
         $crossTestStrings = [
             'B' => $british,
             'A' => $american,
             'C' => $canadian,
             'D' => $australian,
             'Z' => $british_z,
+            '-' => $variation,
         ];
 
         foreach ($crossTestStrings as $from => $preTranslatedString) {
+            if (null === $preTranslatedString) {
+                continue;
+            }
+
+            if (is_array($preTranslatedString)) {
+                $preTranslatedString = $preTranslatedString[0];
+            }
+
             foreach ($crossTestStrings as $to => $expected) {
+                if (null === $expected || $from == $to) {
+                    continue;
+                }
+
+                if (is_array($expected)) {
+                    if ($expected[0] == $preTranslatedString) {
+                        $expected = $expected[0];
+                    } else {
+                        $expected = $expected[1];
+                    }
+                }
+
                 $this->assertSame(
                     $expected,
-                    $translator->translate($preTranslatedString, $from, $to),
+                    $this->translator->translate($preTranslatedString, $from, $to, $questionable),
                     sprintf('Unexpected result on %s to %s translation: %s',
                         $from,
                         $to,

--- a/tests/Amara/Varcon/UtilTest.php
+++ b/tests/Amara/Varcon/UtilTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Amara\Varcon\Tests;
+
+use Amara\Varcon\Util;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests edge-case exceptions where something is wrong with the file.
+ * All other functionality is tested in the Translator test.
+ *
+ * @see TranslatorTest
+ */
+class UtilTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * A A: absinthe / AV B: absinth | :1
+     * ^-^- Having 2 equal variants should not make the word questionable
+     */
+    public function testReadlineNoExpandPrepend()
+    {
+        $util = new Util();
+
+        $this->assertEquals([
+            'A' => [
+                0 => [
+                    0 => 'absinthe',
+                ],
+                3 => [
+                    0 => 'absinth',
+                ],
+                1 => [
+                    0 => 'absinthe',
+                ],
+            ],
+            'B' => [
+                0 => [
+                    0 => 'absinth',
+                ],
+            ],
+        ], $util->readline_no_expand('A A: absinthe / AV B: absinth | :1'));
+    }
+
+    /**
+     * A: absinthe / AV B: absinth | :1 | Too much vertical lines
+     * ---------------------------------^- Extra vertical line
+     */
+    public function testReadlineNoExpandInvalidFormatException()
+    {
+        $util = new Util();
+
+        $this->setExpectedException(\RuntimeException::class, 'Invalid format, there should be 1 vertical line at most');
+        $util->readline_no_expand('A: absinthe / AV B: absinth | :1 | Too much vertical lines');
+    }
+
+    /**
+     * A absinthe / AV B: absinth | :1
+     * -^- Missing colon
+     */
+    public function testReadlineNoExpandBadEntryException()
+    {
+        $util = new Util();
+
+        $this->setExpectedException(\RuntimeException::class, 'Bad entry: A absinthe');
+        $util->readline_no_expand('A absinthe / AV B: absinth | :1');
+    }
+
+    /**
+     * K: absinthe / AV B: absinth | :1
+     * ^- No language for "K" exists
+     */
+    public function testReadlineNoExpandBadCategoryException()
+    {
+        $util = new Util();
+
+        $this->setExpectedException(\RuntimeException::class, 'Bad category: K');
+        $util->readline_no_expand('K: absinthe / AV B: absinth | :1');
+    }
+
+    /**
+     * If the passed parameter evaluates to false, we expect null in return
+     */
+    public function testGetClusterReturnsNullOnEmptyString()
+    {
+        $util = new Util();
+
+        $this->assertSame(null, $util->get_cluster(''));
+    }
+
+    /**
+     * absinthe <verified> (level 50)
+     * ^- Missing #
+     */
+    public function testGetClusterShouldStartWithHashException()
+    {
+        $util = new Util();
+
+        $badCluster = 'absinthe <verified> (level 50)';
+
+        $this->setExpectedException(\RuntimeException::class, sprintf(
+            'Expected cluster to start with comment: %s',
+            $badCluster)
+        );
+        $util->get_cluster($badCluster);
+    }
+
+    /**
+     * #  <verified> (level 50)
+     * -^- Missing word
+     */
+    public function testGetClusterCannotExtractHeadwordException()
+    {
+        $util = new Util();
+
+        $badCluster = '#  <verified> (level 50)';
+
+        $this->setExpectedException(\RuntimeException::class, sprintf(
+            'Could not extract headword from cluster: %s',
+            $badCluster)
+        );
+        $util->get_cluster($badCluster);
+    }
+
+    /**
+     * # absinthe <verified> (level )
+     * ----------------------------^- Missing level
+     */
+    public function testGetClusterCannotExtractLevelException()
+    {
+        $util = new Util();
+
+        $badCluster = '# absinthe <verified> (level )';
+
+        $this->setExpectedException(\RuntimeException::class, sprintf(
+            'Could not extract level from cluster: %s',
+            $badCluster)
+        );
+        $util->get_cluster($badCluster);
+    }
+}


### PR DESCRIPTION
Tidy the code and increase coverage to 100%.

Also fixes an `Undefined index: 1` bug with equal translations

Q   |   A 
------|-------
Type |    Tidy
