### PR TITLE
PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0,<8.0"
+    "php": "^7.2 || ^8.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8"
+    "phpunit/phpunit": "^8.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="VarCon Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/TranslationProvider.php
+++ b/src/TranslationProvider.php
@@ -49,7 +49,7 @@ class TranslationProvider implements TranslationProviderInterface
 
         $trans = [];
 
-        while (false !== ($line = stream_get_line($fileHandle, null, PHP_EOL.PHP_EOL))) {
+        while (false !== ($line = stream_get_line($fileHandle, PHP_INT_MAX, PHP_EOL.PHP_EOL))) {
             $d = $this->util->get_cluster($line);
 
             if ($d['level'] > $threshold) {

--- a/src/TranslationProviderInterface.php
+++ b/src/TranslationProviderInterface.php
@@ -16,5 +16,5 @@ interface TranslationProviderInterface
      *
      * @return array
      */
-    public function getTranslations($from, $to, $threshold);
+    public function getTranslations($from, $to, $threshold = 80);
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -33,7 +33,7 @@ class Translator implements TranslatorInterface
     {
         $trans = $this->provider->getTranslations($fromSpelling, $toSpelling);
 
-        $words = preg_split('/(\'?[^A-Za-z\']+\'?)/', $string, null, PREG_SPLIT_DELIM_CAPTURE);
+        $words = preg_split('/(\'?[^A-Za-z\']+\'?)/', $string, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $return = [];
 

--- a/tests/HtmlCrawlerTest.php
+++ b/tests/HtmlCrawlerTest.php
@@ -3,8 +3,9 @@
 namespace Amara\Varcon\Tests;
 
 use Amara\Varcon\HtmlCrawler;
+use PHPUnit\Framework\TestCase;
 
-class HtmlCrawlerTest extends \PHPUnit_Framework_TestCase
+class HtmlCrawlerTest extends TestCase
 {
     /**
      * @dataProvider provideCrawlAndModifyWithChangedXpathExpressions

--- a/tests/HtmlTranslatorTest.php
+++ b/tests/HtmlTranslatorTest.php
@@ -4,9 +4,10 @@ namespace Amara\Varcon\Tests;
 
 use Amara\Varcon\HtmlTranslator;
 use Amara\Varcon\Translator;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class HtmlTranslatorTest extends \PHPUnit_Framework_TestCase
+class HtmlTranslatorTest extends TestCase
 {
     public function testTranslatePreservesWhitespace()
     {

--- a/tests/TranslationProviderTest.php
+++ b/tests/TranslationProviderTest.php
@@ -2,15 +2,16 @@
 
 namespace Amara\Varcon;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TranslationProviderTest extends PHPUnit_Framework_TestCase
+class TranslationProviderTest extends TestCase
 {
     public function testGetTranslationsFileNotFoundException()
     {
         $translationProvider = new TranslationProvider('random-name-2439857.txt');
 
-        $this->setExpectedException(\RuntimeException::class, 'File not found: ');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('File not found: ');
         $translationProvider->getTranslations('B', 'A');
     }
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -4,7 +4,6 @@ namespace Amara\Varcon\Tests;
 
 use Amara\Varcon\Translator;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_TestCase;
 
 class TranslatorTest extends TestCase
 {

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -3,9 +3,10 @@
 namespace Amara\Varcon\Tests;
 
 use Amara\Varcon\Translator;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_TestCase;
 
-class TranslatorTest extends PHPUnit_Framework_TestCase
+class TranslatorTest extends TestCase
 {
     /**
      * @var Translator
@@ -15,7 +16,7 @@ class TranslatorTest extends PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->translator = new Translator();
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -3,7 +3,7 @@
 namespace Amara\Varcon\Tests;
 
 use Amara\Varcon\Util;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests edge-case exceptions where something is wrong with the file.
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @see TranslatorTest
  */
-class UtilTest extends PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     /**
      * A A: absinthe / AV B: absinth | :1
@@ -49,7 +49,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
     {
         $util = new Util();
 
-        $this->setExpectedException(\RuntimeException::class, 'Invalid format, there should be 1 vertical line at most');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid format, there should be 1 vertical line at most');
         $util->readline_no_expand('A: absinthe / AV B: absinth | :1 | Too much vertical lines');
     }
 
@@ -61,7 +62,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
     {
         $util = new Util();
 
-        $this->setExpectedException(\RuntimeException::class, 'Bad entry: A absinthe');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Bad entry: A absinthe');
         $util->readline_no_expand('A absinthe / AV B: absinth | :1');
     }
 
@@ -73,7 +75,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
     {
         $util = new Util();
 
-        $this->setExpectedException(\RuntimeException::class, 'Bad category: K');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Bad category: K');
         $util->readline_no_expand('K: absinthe / AV B: absinth | :1');
     }
 
@@ -97,7 +100,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
 
         $badCluster = 'absinthe <verified> (level 50)';
 
-        $this->setExpectedException(\RuntimeException::class, sprintf(
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
             'Expected cluster to start with comment: %s',
             $badCluster
         ));
@@ -114,7 +118,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
 
         $badCluster = '#  <verified> (level 50)';
 
-        $this->setExpectedException(\RuntimeException::class, sprintf(
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
             'Could not extract headword from cluster: %s',
             $badCluster
         ));
@@ -131,7 +136,8 @@ class UtilTest extends PHPUnit_Framework_TestCase
 
         $badCluster = '# absinthe <verified> (level )';
 
-        $this->setExpectedException(\RuntimeException::class, sprintf(
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
             'Could not extract level from cluster: %s',
             $badCluster
         ));


### PR DESCRIPTION
Fix issues with PHP 8

Also upgraded to PHPUnit 8.5, the lowest version allowing PHP 8.

```
Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in /var/www/html/src/Translator.php on line 36
Deprecated: stream_get_line(): Passing null to parameter #2 ($length) of type int is deprecated in /var/www/html/src/TranslationProvider.php on line 52
```

Q   |   A
------|-------
Type | Change
Jira | <https://amara-living.atlassian.net/browse/ADPV-728>
